### PR TITLE
Remove PHPStan for PHP/7.1

### DIFF
--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -159,12 +159,12 @@ jobs:
       # - name: Run test suite
       #   run: composer run-script test
 
-      # PHPStan works for PHP/7.1+ so it can't even be in composer.json (as ^5.6|^7.0 is supported)
+      # PHPStan works ok for PHP/7.2+ so PHPStan can't even be in composer.json (as ^5.6|^7.0 might be supported)
       - name: "Composer phpstan-webmozart-assert"
-        if: ${{ matrix.php-version >= '7.1' && steps.vendor-cache.outputs.cache-hit != 'true' }}
+        if: ${{ matrix.php-version >= '7.2' && steps.vendor-cache.outputs.cache-hit != 'true' }}
         run: |
           composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
           #todo return when rector ready for phpstan:1.0#composer require --dev rector/rector --prefer-dist --no-progress
       - name: "PHPStan webmozart-assert"
-        if: ${{ matrix.php-version >= '7.1' }}
+        if: ${{ matrix.php-version >= '7.2' }}
         run: phpstan --configuration=conf/phpstan.webmozart-assert.neon analyse --no-interaction --no-progress .


### PR DESCRIPTION
- to get rid of PHP Fatal error:  Declaration of PHPStan\Reflection\SignatureMap\Php8SignatureMapProvider::getFunctionSignatures(string $functionName, ?string $className, $reflectionFunction): array must be compatible with PHPStan\Reflection\SignatureMap\SignatureMapProvider::getFunctionSignatures(string $functionName, ?string $className, ?ReflectionFunctionAbstract $reflectionFunction): array in phar:///usr/local/bin/phpstan/src/Reflection/SignatureMap/Php8SignatureMapProvider.php on line 34