### PR TITLE
Phinx runs only after composer update. Prettier-fix.

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -18,23 +18,23 @@
 ############################
 # Super-linter Rules by id #
 ############################
-MD004: false                  # Unordered list style
+MD004: false # Unordered list style
 MD007:
-  indent: 2                   # Unordered list indentation
+  indent: 2 # Unordered list indentation
 MD013:
-  line_length: 808            # Line length 80 is far to short
+  line_length: 808 # Line length 80 is far to short
 MD026:
-  punctuation: ".,;:!。，；:"  # List of not allowed
-MD029: false                  # Ordered list item prefix
-MD033: false                  # Allow inline HTML
-MD036: false                  # Emphasis used instead of a heading
+  punctuation: ".,;:!。，；:" # List of not allowed
+MD029: false # Ordered list item prefix
+MD033: false # Allow inline HTML
+MD036: false # Emphasis used instead of a heading
 
 ##############################
 # Super-linter Rules by tags #
 ##############################
-blank_lines: false  # Error on blank lines
+blank_lines: false # Error on blank lines
 
 #####################
 # MyCMS Rules by id #
 #####################
-MD024: false                 # No-duplicate-heading Multiple heading with the same content (in CHANGELOG.md)
+MD024: false # No-duplicate-heading Multiple heading with the same content (in CHANGELOG.md)

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Fetch all history for all branches and tags. Otherwise github.event.pull_request.base.ref SHA isn't found. 
+          fetch-depth: 0 # Fetch all history for all branches and tags. Otherwise github.event.pull_request.base.ref SHA isn't found.
 
       ################################
       # Run Linter against code base #

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -70,7 +70,6 @@ jobs:
           # TODO 211003 returns false positive: {"line":"                    <li><a href=\"https://www.linkedin.com/company/MYCMSPROJECTSPECIFIC\" title=\"{=\"MYCMSPROJECTSPECIFIC na LinkedIn\"|translate}\"><i class=\"fa fa-linkedin\" aria-hidden=\"true\"></i></a></li>","lineNumber":56,"offender":"linkedin.com/company/MYCMSPROJECTSPECIFIC","offenderEntropy":-1,"commit":"","repo":"","repoURL":"","leakURL":"","rule":"LinkedIn Secret Key","commitMessage":"","author":"","email":"","file":".","date":"0001-01-01T00:00:00Z","tags":"secret, LinkedIn"}
           VALIDATE_GITLEAKS: false
           # 240803, there's no way to configure JAVASCRIPT_PRETTIER, neither it shows what exactly an issue is. Just 'Code style issue found in file.', which is useless.
-          VALIDATE_JAVASCRIPT_PRETTIER: false
           VALIDATE_JAVASCRIPT_STANDARD: false
           # TODO VALIDATE_JSCPD later
           VALIDATE_JSCPD: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,11 +18,11 @@ on:
   push:
     branches-ignore:
       # notest branches to ignore testing of partial online commits
-      - 'notest/**'
+      - "notest/**"
   pull_request:
     branches-ignore:
       # notest branches to ignore testing of partial online commits
-      - 'notest/**'
+      - "notest/**"
   workflow_call:
 
 permissions:
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history for all branches and tags. Otherwise github.event.pull_request.base.ref SHA isn't found. 
+          fetch-depth: 0 # Fetch all history for all branches and tags. Otherwise github.event.pull_request.base.ref SHA isn't found. 
 
       ################################
       # Run Linter against code base #

--- a/.github/workflows/overtrue-phplint.yml
+++ b/.github/workflows/overtrue-phplint.yml
@@ -7,9 +7,9 @@ permissions:
   contents: read
 
 jobs:
-# This is how to reuse this workflow:
-#  call-workflow:
-#    uses: WorkOfStan/seablast-actions/.github/workflows/overtrue-phplint.yml@main
+  # This is how to reuse this workflow:
+  #  call-workflow:
+  #    uses: WorkOfStan/seablast-actions/.github/workflows/overtrue-phplint.yml@main
   phplint:
     runs-on: ubuntu-latest
     # Limit the running time

--- a/.github/workflows/overtrue-phplint.yml
+++ b/.github/workflows/overtrue-phplint.yml
@@ -19,4 +19,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check PHP syntax errors
-        uses: overtrue/phplint@9.4.1
+        uses: overtrue/phplint@9.5.3

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -137,14 +137,14 @@ jobs:
         if: steps.check_files_database.outputs.files_exists == 'true'
         run: cp -p "${{ inputs.phinx-config }}" "${{ inputs.phinxlocal-config }}"
 
+      - name: Install dependencies
+        if: ${{ steps.vendor-cache.outputs.cache-hit != 'true' }}
+        run: composer update --prefer-dist --no-progress
+
       - name: Phinx migration - migrate
         #PHP/5.6 has auth problem with MySQL/8
         if: ${{ matrix.php-version >= '7.1' && steps.check_files_database.outputs.files_exists == 'true' }}
         run: ./vendor/bin/phinx migrate -e testing --configuration "${{ inputs.phinx-config }}"
-
-      - name: Install dependencies
-        if: ${{ steps.vendor-cache.outputs.cache-hit != 'true' }}
-        run: composer update --prefer-dist --no-progress
 
       # PHPunit is installed anyway, so it doesn't make sense to use tools: phpunit
       # Note `sudo /etc/init.d/apache2 start` uses `/etc/apache2/sites-enabled/000-default.conf` where DocumentRoot = `/var/www/html` but without PHP

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -31,7 +31,6 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.operating-system }}
     # Limit the running time
     timeout-minutes: 10

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -15,7 +15,7 @@ on:
       phinxlocal-config:
         required: false
         type: string
-        default: "phinx.yml"          
+        default: "phinx.yml"
       # phpdist-config specimen is used to create the actual phplocal-config
       phpdist-config:
         required: false
@@ -48,7 +48,7 @@ jobs:
       # same as phinx.dist.yml-testing
       DB_DATABASE: testing_db
       DB_USER: root
-      DB_PASSWORD: 'root'
+      DB_PASSWORD: "root"
       #DB_HOST: localhost
 
     steps:
@@ -74,7 +74,7 @@ jobs:
       # Check syntax for the specific PHP version
       - name: Check PHP syntax ${{ steps.php_version.outputs.version }}
         run: find ./ -name "*.php" -print0 | xargs -0 -n 1 php -l
-  
+
       # Database tests should fire up only if the specified Phinx config file is present
       - name: Check database config file existence
         id: check_files_database

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -1,0 +1,20 @@
+---
+name: Prettier-fix
+on: [pull_request, push]
+
+permissions:
+  contents: write
+
+jobs:
+  prettier-fix:
+    # Run only if the actor is not the GitHub Actions bot
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    # Limit the running time
+    timeout-minutes: 10
+    steps:
+      - name: Invoke the Prettier fix
+        # Use the latest commit in the main branch.
+        uses: WorkOfStan/prettier-fix@main
+        #with:
+        #  node-version: "20"

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - name: Invoke the Prettier fix
         # Use the latest commit in the main branch.
-        uses: WorkOfStan/prettier-fix@feature/fix103
+        uses: WorkOfStan/prettier-fix@main
         #with:
         #  node-version: "20"

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - name: Invoke the Prettier fix
         # Use the latest commit in the main branch.
-        uses: WorkOfStan/prettier-fix@main
+        uses: WorkOfStan/prettier-fix@feature/fix103
         #with:
         #  node-version: "20"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
-- php-composer-dependencies-reusable: phinx runs only after composer update, so that phinx can be in require-dev section
+- php-composer-dependencies-reusable: phinx runs only after composer update (not just no-dev), so that phinx can be in require-dev section
 - [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
 
 ### `Deprecated` for soon-to-be removed features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Check PHP syntax for each PHP version separately
 
 ### `Changed` for changes in existing functionality
-- `VALIDATE_JAVASCRIPT_PRETTIER: false` as there's no way to configure JAVASCRIPT_PRETTIER, neither it shows what exactly an issue is. Just 'Code style issue found in file.', which is useless.
+- php-composer-dependencies-reusable: phinx runs only after composer update, so that phinx can be in require-dev section
+- [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### `Added` for new features
+
 - Check PHP syntax for each PHP version separately
 
 ### `Changed` for changes in existing functionality
+
 - php-composer-dependencies-reusable: phinx runs only after composer update, so that phinx can be in require-dev section
 - [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
 
@@ -21,21 +25,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Security` in case of vulnerabilities
 
 ## [0.1.1] - 2024-05-29
+
 ### Changed
+
 - php-composer-dependencies-reusable: phinx and dist config file path can be modified
 
 ### Fixed
+
 - linter.yml: DEFAULT_BRANCH adapts to the current branch. `actions/checkout with fetch-depth: 0` to fetch all history for all branches and tags to provide history with pull_request.
 
 ## [0.1] - 2024-05-19
+
 Proven reusable workflows
+
 ### Added
+
 - php-composer-dependencies-reusable.yml: Test composer dependencies, PHPUnit tests and PHPStan check
 - overtrue-phplint.yml: Basic PHP linter
 - linter.yml: [Super-Linter](https://github.com/super-linter/super-linter) of many formats
 - Automatic PHP improvements: phpcbf.yml
 
 ### Fixed
+
 - added .shfmt configuration for super-linter but VALIDATE_SHELL_SHFMT: false is the only solution, anyway
 
 [Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.1.1...HEAD

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Supports: "php": "5.6 || ^7.0 || ^8.0"
 See <https://github.com/WorkOfStan/seablast-dist/tree/main/.github/workflows> for an actual example.
 
 ## Test composer dependencies, PHPUnit tests and PHPStan check
+
 ```yml
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
@@ -19,7 +20,7 @@ jobs:
       # OPTIONAL path with the default database configuration
       phinx-config: "phinx.dist.yml"
       # OPTIONAL path where the app code is looking for the database configuration
-      phinxlocal-config: "phinx.yml"          
+      phinxlocal-config: "phinx.yml"
       # OPTIONAL path to phpdist-config specimen which is used to create the actual phplocal-config
       phpdist-config: "./conf/app.conf.dist.php"
       phplocal-config: "./conf/app.conf.local.php"
@@ -28,6 +29,7 @@ jobs:
 PHPUnit tests fire up only if `conf/phpunit-github.xml` is present. (This configuration may be different from the usual `./phpunit.xml`.)
 
 ## Basic PHP linter
+
 ```yml
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
@@ -36,6 +38,7 @@ jobs:
 ```
 
 ## [Super-Linter](https://github.com/super-linter/super-linter) of many formats
+
 ```yml
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
@@ -49,16 +52,20 @@ While you can still rely on your favorite IDE to apply Prettier's formatting, wh
 Use [prettier-fix](https://github.com/marketplace/actions/prettier-fix).
 
 ### SHFMT notes
+
 Super-linter configuration in [linter.yml](./github/workflows/linter.yml) refering to <.github/linters/.shfmt>
+
 ```yml
 SHELL_SHFMT_FILE_NAME: .shfmt
 ```
+
 is ignored in the end, as the code doesn't use the configuration:
 see <https://github.com/super-linter/super-linter/blob/main/lib/functions/linterCommands.sh> -> `LINTER_COMMANDS_ARRAY_SHELL_SHFMT=(shfmt -d)`
 
 And the default is to use 1 TAB as indentations, while the coding standard used here expects 4 spaces, so SHALL_SHFMT validation is turned off.
 
 ## Automatic PHP Code Style improvements
+
 ```yml
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ jobs:
     uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@main
 ```
 
+With the release of [Super-Linter](https://github.com/super-linter/super-linter) 7.0.0, [Prettier](https://prettier.io/) has become the standard for many file formats, ensuring consistent code styling across your projects.
+Embrace this change and keep your codebase looking sharp by integrating Prettier directly into your workflow.
+While you can still rely on your favorite IDE to apply Prettier's formatting, why not automate the process with this GitHub Action using vanilla Prettier?
+Use [prettier-fix](https://github.com/marketplace/actions/prettier-fix).
+
 ### SHFMT notes
 Super-linter configuration in [linter.yml](./github/workflows/linter.yml) refering to <.github/linters/.shfmt>
 ```yml

--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ jobs:
 ```
 
 With the release of [Super-Linter](https://github.com/super-linter/super-linter) 7.0.0, [Prettier](https://prettier.io/) has become the standard for many file formats, ensuring consistent code styling across your projects.
-Embrace this change and keep your codebase looking sharp by integrating Prettier directly into your workflow.
-While you can still rely on your favorite IDE to apply Prettier's formatting, why not automate the process with this GitHub Action using vanilla Prettier?
-Use [prettier-fix](https://github.com/marketplace/actions/prettier-fix).
+Embrace this change and keep your codebase looking sharp by integrating Prettier directly into your workflow: [prettier-fix](https://github.com/marketplace/actions/prettier-fix).
 
 ### SHFMT notes
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Supports: "php": "5.6 || ^7.0 || ^8.0"
 
 See <https://github.com/WorkOfStan/seablast-dist/tree/main/.github/workflows> for an actual example.
 
-## Test composer dependencies, PHPUnit tests and PHPStan check
+## Test composer dependencies, PHPUnit tests (incl. database) and PHPStan check
 
 ```yml
 jobs:


### PR DESCRIPTION
### Changed

- php-composer-dependencies-reusable: phinx runs only after composer update (not just no-dev), so that phinx can be in require-dev section
- [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter