### PR TITLE
Check PHP syntax and install PHPStan for each PHP version separately

### DIFF
--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -7,20 +7,22 @@ on:
       php-version:
         required: true
         type: string
+      # OPTIONAL path with the default database configuration
       phinx-config:
         required: false
         type: string
         default: "phinx.dist.yml"
-      # path where the app code is looking for the configuration
+      # OPTIONAL path where the app code is looking for the database configuration
       phinxlocal-config:
         required: false
         type: string
         default: "phinx.yml"
-      # phpdist-config specimen is used to create the actual phplocal-config
+      # OPTIONAL phpdist-config specimen is used to create the actual phplocal-config
       phpdist-config:
         required: false
         type: string
         default: "./conf/app.conf.dist.php"
+      # OPTIONAL path where the app code is looking for the local app configuration
       phplocal-config:
         required: false
         type: string
@@ -58,8 +60,9 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2, phpstan
-          # Note: phpstan call fails for PHP<7.1
+          tools: composer:v2
+          # phpstan added by tools is the latest one, which may not be supported: e.g. phpstan:2.0.1 fails php:7.2,7.3
+          # Note: when phpstan is added by tools phpstan call fails for PHP<7.1
           # coverage none turns off Xdebug as in PHP 5.6,7.0 it would change (format) var_dump output
           coverage: none
         env:
@@ -163,7 +166,8 @@ jobs:
         if: ${{ matrix.php-version >= '7.2' && steps.vendor-cache.outputs.cache-hit != 'true' }}
         run: |
           composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
-          #todo return when rector ready for phpstan:1.0#composer require --dev rector/rector --prefer-dist --no-progress
+          # this will also add the supported version of phpstan/phpstan
+
       - name: "PHPStan webmozart-assert"
         if: ${{ matrix.php-version >= '7.2' }}
-        run: phpstan --configuration=conf/phpstan.webmozart-assert.neon analyse --no-interaction --no-progress .
+        run: ./vendor/bin/phpstan.phar --configuration=conf/phpstan.webmozart-assert.neon analyse --no-interaction --no-progress .

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -164,9 +164,8 @@ jobs:
       # PHPStan works ok for PHP/7.2+ so PHPStan can't even be in composer.json (as ^5.6|^7.0 might be supported)
       - name: "Composer phpstan-webmozart-assert"
         if: ${{ matrix.php-version >= '7.2' && steps.vendor-cache.outputs.cache-hit != 'true' }}
-        run: |
-          composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
-          # this will also add the supported version of phpstan/phpstan
+        run: composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
+        # this will also add the supported version of phpstan/phpstan
 
       - name: "PHPStan webmozart-assert"
         if: ${{ matrix.php-version >= '7.2' }}

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -155,12 +155,6 @@ jobs:
         if: ${{ matrix.php-version >= '7.1' && steps.check_files_phpunit.outputs.files_exists == 'true' }}
         run: ./vendor/bin/phpunit -c ./conf/phpunit-github.xml
 
-      # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
-      # Docs: https://getcomposer.org/doc/articles/scripts.md
-
-      # - name: Run test suite
-      #   run: composer run-script test
-
       # PHPStan works ok for PHP/7.2+ so PHPStan can't even be in composer.json (as ^5.6|^7.0 might be supported)
       - name: "Composer phpstan-webmozart-assert"
         if: ${{ matrix.php-version >= '7.2' && steps.vendor-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
         default: "phinx.yml"
-      # OPTIONAL phpdist-config specimen is used to create the actual phplocal-config
+      # OPTIONAL path to phpdist-config specimen which is used to create the actual phplocal-config
       phpdist-config:
         required: false
         type: string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added` for new features
 
-- Check PHP syntax for each PHP version separately
-
 ### `Changed` for changes in existing functionality
-
-- php-composer-dependencies-reusable: phinx runs only after composer update (not just no-dev), so that phinx can be in require-dev section
-- [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
-- phpstan added with tools of shivammathur/setup-php@v2 is the latest one, which may not be supported (e.g. phpstan:2.0.1 fails php:7.2,7.3) so phpstan is now installed by `composer require --dev phpstan/phpstan-webmozart-assert`
 
 ### `Deprecated` for soon-to-be removed features
 
@@ -24,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+## [0.2] - 2024-11-16
+
+### Added
+
+- Check PHP syntax for each PHP version separately
+
+### Changed
+
+- php-composer-dependencies-reusable: phinx runs only after composer update (not just no-dev), so that phinx can be in require-dev section
+- [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
+- phpstan added with tools of shivammathur/setup-php@v2 is the latest one, which may not be supported (e.g. phpstan:2.0.1 fails php:7.2,7.3), so phpstan is now installed by `composer require --dev phpstan/phpstan-webmozart-assert`
 
 ## [0.1.1] - 2024-05-29
 
@@ -50,6 +56,7 @@ Proven reusable workflows
 
 - added .shfmt configuration for super-linter but VALIDATE_SHELL_SHFMT: false is the only solution, anyway
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2...HEAD
+[0.2]: https://github.com/WorkOfStan/seablast-actions/compare/v0.1.1...v0.2
 [0.1.1]: https://github.com/WorkOfStan/seablast-actions/compare/v0.1...v0.1.1
 [0.1]: https://github.com/WorkOfStan/seablast-actions/releases/tag/v0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - php-composer-dependencies-reusable: phinx runs only after composer update (not just no-dev), so that phinx can be in require-dev section
 - [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
+- phpstan added with tools of shivammathur/setup-php@v2 is the latest one, which may not be supported (e.g. phpstan:2.0.1 fails php:7.2,7.3) so phpstan is now installed by `composer require --dev phpstan/phpstan-webmozart-assert`
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ jobs:
       phinxlocal-config: "phinx.yml"
       # OPTIONAL path to phpdist-config specimen which is used to create the actual phplocal-config
       phpdist-config: "./conf/app.conf.dist.php"
+      # OPTIONAL path where the app code is looking for the local app configuration
       phplocal-config: "./conf/app.conf.local.php"
 ```
 


### PR DESCRIPTION
### Added

- Check PHP syntax for each PHP version separately

### Changed

- php-composer-dependencies-reusable: phinx runs only after composer update (not just no-dev), so that phinx can be in require-dev section
- [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
- phpstan added with tools of shivammathur/setup-php@v2 is the latest one, which may not be supported (e.g. phpstan:2.0.1 fails php:7.2,7.3), so phpstan is now installed by `composer require --dev phpstan/phpstan-webmozart-assert`