### PR TITLE
Fetch the latest changes to allow job chaining

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -41,7 +41,7 @@ jobs:
     # Name the Job
     name: Lint Code Base
     # Set the agent to run on
-    runs-on: "${{ inputs.runs-on }}"
+    runs-on: "${{ inputs.runs-on || 'ubuntu-latest' }}"
     # Limit the running time
     timeout-minutes: 10
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,6 +24,11 @@ on:
       # notest branches to ignore testing of partial online commits
       - "notest/**"
   workflow_call:
+    inputs:
+      runs-on:
+        required: false
+        type: string
+        default: "ubuntu-latest"
 
 permissions:
   contents: read
@@ -36,7 +41,7 @@ jobs:
     # Name the Job
     name: Lint Code Base
     # Set the agent to run on
-    runs-on: ubuntu-latest
+    runs-on: "${{ inputs.runs-on }}"
     # Limit the running time
     timeout-minutes: 10
 
@@ -50,7 +55,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref }}
           fetch-depth: 0 # Fetch all history for all branches and tags. Otherwise github.event.pull_request.base.ref SHA isn't found.
+      # Fetch latest changes (even by previous job)
+      - name: Fetch latest changes
+        run: git pull origin ${{ github.ref }}
 
       ################################
       # Run Linter against code base #

--- a/.github/workflows/overtrue-phplint.yml
+++ b/.github/workflows/overtrue-phplint.yml
@@ -2,6 +2,11 @@
 name: PHP Linting (Overtrue)
 on:
   workflow_call:
+    inputs:
+      runs-on:
+        required: false
+        type: string
+        default: "ubuntu-latest"
 
 permissions:
   contents: read
@@ -11,12 +16,18 @@ jobs:
   #  call-workflow:
   #    uses: WorkOfStan/seablast-actions/.github/workflows/overtrue-phplint.yml@main
   phplint:
-    runs-on: ubuntu-latest
+    runs-on: "${{ inputs.runs-on }}"
     # Limit the running time
     timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0 # Fetch all history for all branches and tags. Otherwise github.event.pull_request.base.ref SHA isn't found.
+      # Fetch latest changes (even by previous job)
+      - name: Fetch latest changes
+        run: git pull origin ${{ github.ref }}
 
       - name: Check PHP syntax errors
         uses: overtrue/phplint@9.5.5

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -1,5 +1,5 @@
 ---
-name: PHP Composer + PHPUnit + PHPStan
+name: PHP Composer _ PHPUnit _ PHPStan
 
 on:
   workflow_call:
@@ -27,6 +27,10 @@ on:
         required: false
         type: string
         default: "./conf/app.conf.local.php"
+      runs-on:
+        required: false
+        type: string
+        default: "ubuntu-latest"
 
 permissions:
   contents: read
@@ -39,7 +43,7 @@ jobs:
     strategy:
       matrix:
         operating-system:
-          - "ubuntu-latest"
+          - "${{ inputs.runs-on }}"
         php-version: ${{ fromJson(inputs.php-version) }}
         # If the bug https://bugs.php.net/bug.php?id=73803 materializes, then remove 7.1 from php-version list above, as
         # ZipArchive class has public properties, that are not visible via reflection in PHP/7.1.
@@ -55,6 +59,12 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0 # Fetch all history for all branches and tags. Otherwise github.event.pull_request.base.ref SHA isn't found.
+      # Fetch latest changes (even by previous job)
+      - name: Fetch latest changes
+        run: git pull origin ${{ github.ref }}
 
       - name: "Install PHP ${{ matrix.php-version }} Test on ${{ runner.os }}"
         uses: "shivammathur/setup-php@v2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [0.2.1] - 2025-01-18
+
+### Added
+
+- runs-on input can change the runner for reusable workflows linter.yml, overtrue-phplint.yml and php-composer-dependencies-reusable.yml
+
+### Fixed
+
+- the reusable workflows linter.yml, overtrue-phplint.yml and php-composer-dependencies-reusable.yml fetch the latest changes even by a previous job to allow for job chaining
+
 ## [0.2] - 2024-11-16
 
 ### Added
@@ -56,7 +66,8 @@ Proven reusable workflows
 
 - added .shfmt configuration for super-linter but VALIDATE_SHELL_SHFMT: false is the only solution, anyway
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2...v0.2.1
 [0.2]: https://github.com/WorkOfStan/seablast-actions/compare/v0.1.1...v0.2
 [0.1.1]: https://github.com/WorkOfStan/seablast-actions/compare/v0.1...v0.1.1
 [0.1]: https://github.com/WorkOfStan/seablast-actions/releases/tag/v0.1

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ jobs:
       phpdist-config: "./conf/app.conf.dist.php"
       # OPTIONAL path where the app code is looking for the local app configuration
       phplocal-config: "./conf/app.conf.local.php"
+      # OPTIONAL runner specification
+      runs-on: "ubuntu-latest"
 ```
 
 PHPUnit tests fire up only if `conf/phpunit-github.xml` is present. (This configuration may be different from the usual `./phpunit.xml`.)
@@ -36,6 +38,9 @@ jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   call-workflow:
     uses: WorkOfStan/seablast-actions/.github/workflows/overtrue-phplint.yml@main
+    with:
+      # OPTIONAL runner specification
+      runs-on: "ubuntu-latest"
 ```
 
 ## [Super-Linter](https://github.com/super-linter/super-linter) of many formats
@@ -45,6 +50,9 @@ jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   call-workflow:
     uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@main
+    with:
+      # OPTIONAL runner specification
+      runs-on: "ubuntu-latest"
 ```
 
 With the release of [Super-Linter](https://github.com/super-linter/super-linter) 7.0.0, [Prettier](https://prettier.io/) has become the standard for many file formats, ensuring consistent code styling across your projects.


### PR DESCRIPTION
### Added

- runs-on input can change the runner for reusable workflows linter.yml, overtrue-phplint.yml and php-composer-dependencies-reusable.yml

### Fixed

- the reusable workflows linter.yml, overtrue-phplint.yml and php-composer-dependencies-reusable.yml fetch the latest changes even by a previous job to allow for job chaining
