### PR TITLE
The cache name starts with `phps-` prefix. PHPCS-fix instead of old phpcbf.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,5 @@ updates:
     # Location of package manifests
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
+      # Check for updates to GitHub Actions every monthly
+      interval: "monthly"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -60,6 +60,7 @@ jobs:
       # Fetch latest changes (even by previous job)
       - name: Fetch latest changes
         run: git pull origin ${{ github.ref }}
+        shell: bash
 
       ################################
       # Run Linter against code base #

--- a/.github/workflows/overtrue-phplint.yml
+++ b/.github/workflows/overtrue-phplint.yml
@@ -28,6 +28,7 @@ jobs:
       # Fetch latest changes (even by previous job)
       - name: Fetch latest changes
         run: git pull origin ${{ github.ref }}
+        shell: bash
 
       - name: Check PHP syntax errors
         uses: overtrue/phplint@9.5.5

--- a/.github/workflows/overtrue-phplint.yml
+++ b/.github/workflows/overtrue-phplint.yml
@@ -31,4 +31,4 @@ jobs:
         shell: bash
 
       - name: Check PHP syntax errors
-        uses: overtrue/phplint@9.5.5
+        uses: overtrue/phplint@9.5.6

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -65,6 +65,7 @@ jobs:
       # Fetch latest changes (even by previous job)
       - name: Fetch latest changes
         run: git pull origin ${{ github.ref }}
+        shell: bash
 
       - name: "Install PHP ${{ matrix.php-version }} Test on ${{ runner.os }}"
         uses: "shivammathur/setup-php@v2"
@@ -82,10 +83,12 @@ jobs:
       - name: Get PHP version
         id: php_version
         run: echo "version=$(php -r 'echo PHP_VERSION;')" >> "$GITHUB_OUTPUT"
+        shell: bash
 
       # Check syntax for the specific PHP version
       - name: Check PHP syntax ${{ steps.php_version.outputs.version }}
         run: find ./ -name "*.php" -print0 | xargs -0 -n 1 php -l
+        shell: bash
 
       # Database tests should fire up only if the specified Phinx config file is present
       - name: Check database config file existence
@@ -117,6 +120,7 @@ jobs:
           mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';" -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
           mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
           mysql -e 'SHOW DATABASES;' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
+        shell: bash
 
       # https://github.com/actions/cache
       # A repository can have up to 10 GB of caches. Once the 10 GB limit is reached, older caches will be evicted based on when the cache was last accessed.
@@ -135,28 +139,34 @@ jobs:
       - name: Validate composer.json and composer.lock
         if: ${{ steps.vendor-cache.outputs.cache-hit != 'true' }}
         run: composer validate
+        shell: bash
 
       - name: Install no-dev dependencies
         if: ${{ steps.vendor-cache.outputs.cache-hit != 'true' }}
         run: composer update --no-dev --prefer-dist --no-progress
+        shell: bash
 
       # to fix `Constant DB_USERNAME not found.` etc not only for phpstan but also for phpunit tests
       - name: Copy local config files
         if: steps.check_files_configlocaldist.outputs.files_exists == 'true'
         run: cp -p "${{ inputs.phpdist-config }}" "${{ inputs.phplocal-config }}"
+        shell: bash
 
       - name: Copy local testing database settings
         if: steps.check_files_database.outputs.files_exists == 'true'
         run: cp -p "${{ inputs.phinx-config }}" "${{ inputs.phinxlocal-config }}"
+        shell: bash
 
       - name: Install dependencies
         if: ${{ steps.vendor-cache.outputs.cache-hit != 'true' }}
         run: composer update --prefer-dist --no-progress
+        shell: bash
 
       - name: Phinx migration - migrate
         #PHP/5.6 has auth problem with MySQL/8
         if: ${{ matrix.php-version >= '7.1' && steps.check_files_database.outputs.files_exists == 'true' }}
         run: ./vendor/bin/phinx migrate -e testing --configuration "${{ inputs.phinx-config }}"
+        shell: bash
 
       # PHPunit is installed anyway, so it doesn't make sense to use tools: phpunit
       # Note `sudo /etc/init.d/apache2 start` uses `/etc/apache2/sites-enabled/000-default.conf` where DocumentRoot = `/var/www/html` but without PHP
@@ -164,12 +174,14 @@ jobs:
       - name: "PHPUnit tests with MySQL"
         if: ${{ matrix.php-version >= '7.1' && steps.check_files_phpunit.outputs.files_exists == 'true' }}
         run: ./vendor/bin/phpunit -c ./conf/phpunit-github.xml
+        shell: bash
 
       # PHPStan works ok for PHP/7.2+ so PHPStan can't even be in composer.json (as ^5.6|^7.0 might be supported)
       - name: "Composer phpstan-webmozart-assert"
         if: ${{ matrix.php-version >= '7.2' && steps.vendor-cache.outputs.cache-hit != 'true' }}
         run: composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
         # this will also add the supported version of phpstan/phpstan
+        shell: bash
 
       - name: "PHPStan webmozart-assert"
         if: ${{ matrix.php-version >= '7.2' }}
@@ -178,3 +190,4 @@ jobs:
           ./vendor/bin/phpstan.phar -V
           # analyze
           ./vendor/bin/phpstan.phar --configuration=conf/phpstan.webmozart-assert.neon analyse --no-interaction --no-progress .
+        shell: bash

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -132,7 +132,7 @@ jobs:
           # path to Checkout working directory is /home/runner/work/repo-name/repo-name , so just add /vendor/
           path: ${{ github.workspace }}/vendor/
           # Use composer.json for key, if composer.lock is not committed.
-          key: phpstan-${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}
+          key: phps-${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}
           # key: ${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.lock') }}
           #restore-keys: ${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-
 

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -132,7 +132,7 @@ jobs:
           # path to Checkout working directory is /home/runner/work/repo-name/repo-name , so just add /vendor/
           path: ${{ github.workspace }}/vendor/
           # Use composer.json for key, if composer.lock is not committed.
-          key: ${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}
+          key: phpstan-${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}
           # key: ${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.lock') }}
           #restore-keys: ${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-
 

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -14,6 +14,10 @@ jobs:
     # Limit the running time
     timeout-minutes: 10
     steps:
+      - name: Run PHP Code Beautifier if needed
+        run: echo "::warning title=This GitHub Action is deprecated.::Use https://github.com/marketplace/actions/phpcs-fix instead."
+        shell: bash
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -24,7 +28,7 @@ jobs:
           # The installed coding standards are MySource, PEAR, PSR1, PSR12, PSR2, Squiz and Zend
           # Fixes PHP, JS, CSS and maybe other formats as well. It is possible to limit it by --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md,yml
           # Ignore big js libraries not to exhaust memory
-          args: --standard=PSR12 --ignore=vendor,bootstrap,popper,jquery,summernote,Cookies,autrotrack,owlcarousel,ie10-viewport-bug-workaround.js,font-awesome .
+          args: --standard=PSR12 --ignore=vendor,bootstrap,popper,jquery,summernote,Cookies,autotrack,owlcarousel,ie10-viewport-bug-workaround.js,font-awesome .
           #args: --standard=PSR12 --ignore=vendor /github/workspace/
 
       # make the changes between checkout and push

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   prettier-fix:
     # Run only if the actor is not the GitHub Actions bot
-    if: github.actor != 'github-actions[bot]'
+    # if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     # Limit the running time
     timeout-minutes: 10

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -22,6 +22,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Invoke the Prettier fix
-        uses: WorkOfStan/prettier-fix@v1.1.0
+        uses: WorkOfStan/prettier-fix@v1.1.2
         with:
           commit-changes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The cache name (key) is `phpstan-${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}`
+- The cache name (key) is `phps-${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added` for new features
 
-- chain jobs example
-
 ### `Changed` for changes in existing functionality
 
 ### `Deprecated` for soon-to-be removed features
-
-- stop using [phpcbf.yml](.github/workflows/phpcbf.yml) and start using [PHPCS-Fix](https://github.com/WorkOfStan/phpcs-fix/blob/main/.github/workflows/phpcs-phpcbf.yml)
 
 ### `Removed` for now removed features
 
 ### `Fixed` for any bugfixes
 
-- `shell: bash` added where missing
-
 ### `Security` in case of vulnerabilities
+
+## [0.2.2] - 2025-02-21
+
+### Added
+
+- chain jobs example
+
+### Changed
+
+- The cache name (key) is `phpstan-${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}`
+
+### Deprecated
+
+- stop using [phpcbf.yml](.github/workflows/phpcbf.yml) and start using [PHPCS-Fix](https://github.com/WorkOfStan/phpcs-fix/blob/main/.github/workflows/phpcs-phpcbf.yml)
+
+### Fixed
+
+- `shell: bash` added where missing
 
 ## [0.2.1] - 2025-01-18
 
@@ -73,7 +85,8 @@ Proven reusable workflows
 
 - added .shfmt configuration for super-linter but VALIDATE_SHELL_SHFMT: false is the only solution, anyway
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2...v0.2.1
 [0.2]: https://github.com/WorkOfStan/seablast-actions/compare/v0.1.1...v0.2
 [0.1.1]: https://github.com/WorkOfStan/seablast-actions/compare/v0.1...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added` for new features
 
+- chain jobs example
+
 ### `Changed` for changes in existing functionality
 
 ### `Deprecated` for soon-to-be removed features
 
+- stop using [phpcbf.yml](.github/workflows/phpcbf.yml) and start using [PHPCS-Fix](https://github.com/WorkOfStan/phpcs-fix/blob/main/.github/workflows/phpcs-phpcbf.yml)
+
 ### `Removed` for now removed features
 
 ### `Fixed` for any bugfixes
+
+- `shell: bash` added where missing
 
 ### `Security` in case of vulnerabilities
 
@@ -23,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- show PHPStan version before analyzing
 - runs-on input can change the runner for reusable workflows linter.yml, overtrue-phplint.yml and php-composer-dependencies-reusable.yml
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To optimize execution time, the `vendor` folder is cached, allowing dependencies
 
 This approach enables cache sharing across branches. However, if the `composer.json` file in the referenced branch (e.g., `dev`) changes, it's recommended to **invalidate the cache** to ensure a fresh `vendor` folder is built from scratch.
 
-The cache name (key) is `phpstan-${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}`
+The cache name (key) is `phps-${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}` (because the vendor folder includes PHPStan)
 
 ## Basic PHP linter
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,20 @@ Streamline your development process and ensure consistent build, test, and deplo
 Supports: "php": "5.6 || ^7.0 || ^8.0"
 
 ## Example
+
 See <https://github.com/WorkOfStan/seablast-dist/tree/main/.github/workflows> for an actual example.
 
 Note that there are two ways to chain jobs (as typically you want to lint a code only if it is actually working [not to waste computing time]).
 One is to trigger workflows by running another workflow successfully first:
 
 ```yaml
- on:
+on:
   workflow_run:
     workflows:
       - First Action
     types:
       - completed
-```      
+```
 
 but as this condition works **ONLY** on the default branch, and typically you need to run workflows on dev branches to make sure the code is working and well formatted,
 there's the second way. Chaining jobs within a single workflow by using `needs` command.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ jobs:
 
 PHPUnit tests fire up only if `conf/phpunit-github.xml` is present. (This configuration may be different from the usual `./phpunit.xml`.)
 
+### Caching Mechanism
+
+To optimize execution time, the `vendor` folder is cached, allowing dependencies to be reused across workflow runs. The cache key is generated based on:
+
+- `composer.json` – to track dependency changes.
+- The runner's OS and PHP version – to account for environment-specific variations.
+
+This approach enables cache sharing across branches. However, if the `composer.json` file in the referenced branch (e.g., `dev`) changes, it's recommended to **invalidate the cache** to ensure a fresh `vendor` folder is built from scratch.
+
+The cache name (key) is `phpstan-${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}`
+
 ## Basic PHP linter
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -5,7 +5,24 @@ Streamline your development process and ensure consistent build, test, and deplo
 
 Supports: "php": "5.6 || ^7.0 || ^8.0"
 
+## Example
 See <https://github.com/WorkOfStan/seablast-dist/tree/main/.github/workflows> for an actual example.
+
+Note that there are two ways to chain jobs (as typically you want to lint a code only if it is actually working [not to waste computing time]).
+One is to trigger workflows by running another workflow successfully first:
+
+```yaml
+ on:
+  workflow_run:
+    workflows:
+      - First Action
+    types:
+      - completed
+```      
+
+but as this condition works **ONLY** on the default branch, and typically you need to run workflows on dev branches to make sure the code is working and well formatted,
+there's the second way. Chaining jobs within a single workflow by using `needs` command.
+See <https://github.com/WorkOfStan/seablast-dist/blob/main/.github/workflows/polish-the-code.yml> for an actual example.
 
 ## Test composer dependencies, PHPUnit tests (incl. database) and PHPStan check
 
@@ -73,11 +90,4 @@ And the default is to use 1 TAB as indentations, while the coding standard used 
 
 ## Automatic PHP Code Style improvements
 
-```yml
-jobs:
-  # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
-  call-workflow:
-    uses: WorkOfStan/seablast-actions/.github/workflows/phpcbf.yml@main
-```
-
-See an example [phpcbf.yml](https://github.com/WorkOfStan/seablast-dist/blob/main/.github/workflows/phpcbf.yml) for usage.
+Use [PHPCS-Fix](https://github.com/WorkOfStan/phpcs-fix/blob/main/.github/workflows/phpcs-phpcbf.yml).


### PR DESCRIPTION
### Added

- chain jobs example

### Changed

- The cache name (key) is `phps-${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}`

### Deprecated

- stop using [phpcbf.yml](.github/workflows/phpcbf.yml) and start using [PHPCS-Fix](https://github.com/WorkOfStan/phpcs-fix/blob/main/.github/workflows/phpcs-phpcbf.yml)

### Fixed

- `shell: bash` added where missing