### PR TITLE
fix: uses super-linter:v7.2.1 which doesn't invoke composer

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -83,12 +83,12 @@ jobs:
       # Run Linter against code base #
       ################################
       # The `uses` field is processed before any runtime expressions are evaluated. As a result, even if you define an environment variable or output, you can’t reference it in the `uses` field.
-      # This restriction forces us to either hardcode the version or use conditional steps with static strings.      
+      # This restriction forces us to either hardcode the version or use conditional steps with static strings.
       # When your workflow is triggered via a workflow_call, the inputs (like inputs.linter-version) are available for use in expressions throughout the workflow (for example, in environment variables or conditionals).
       # However, the `uses` field in a step is processed very early—before runtime—so it requires a static string.
       - name: Lint Code Base (Workflow Call)
         if: ${{ github.event_name == 'workflow_call' }}
-        uses: super-linter/super-linter${{ inputs.linter-version }}
+        uses: super-linter/super-linter${{ inputs['linter-version'] }}
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -77,7 +77,7 @@ jobs:
       ################################
       # Run Linter against code base #
       ################################
-      - name: Lint Code Base (Default)
+      - name: Lint Code Base
         uses: super-linter/super-linter/slim@v7.2.1
         env:
           VALIDATE_ALL_CODEBASE: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -29,6 +29,11 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
+      linter-version:
+        required: false
+        type: string
+        # This parameter allows you to change the super-linter version/branch, e.g. '/slim-latest', '@v7.2.1', '/slim@v7.2.1'
+        default: "@main"
 
 permissions:
   contents: read
@@ -62,14 +67,32 @@ jobs:
         run: git pull origin ${{ github.ref }}
         shell: bash
 
+      # Dump the GitHub variables
+      - name: Dump GitHub Variables
+        run: |
+          echo "GitHub Event Name: ${{ github.event_name }}"
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          GITHUB_EVENT_PULL_REQUEST_BASE_NAME: ${{ github.event.pull_request.base.name }}
+        shell: bash
+
       ################################
       # Run Linter against code base #
       ################################
-      - name: Lint Code Base
-        uses: super-linter/super-linter@main
+      # The `uses` field is processed before any runtime expressions are evaluated. As a result, even if you define an environment variable or output, you can’t reference it in the `uses` field.
+      # This restriction forces us to either hardcode the version or use conditional steps with static strings.      
+      # When your workflow is triggered via a workflow_call, the inputs (like inputs.linter-version) are available for use in expressions throughout the workflow (for example, in environment variables or conditionals).
+      # However, the `uses` field in a step is processed very early—before runtime—so it requires a static string.
+      - name: Lint Code Base (Workflow Call)
+        if: ${{ github.event_name == 'workflow_call' }}
+        uses: super-linter/super-linter${{ inputs.linter-version }}
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+          FILTER_REGEX_EXCLUDE: '.*\/vendor\/.*'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.yml
           #SHELL_SHFMT_FILE_NAME: .shfmt
@@ -83,7 +106,34 @@ jobs:
           VALIDATE_JAVASCRIPT_STANDARD: false
           # TODO VALIDATE_JSCPD later
           VALIDATE_JSCPD: false
-          # PHPStan run in matrix strategy in php-composer-phpunit.yml
+          # PHPStan run in matrix strategy in php-composer-dependencies-reusable.yml
+          VALIDATE_PHP_PHPSTAN: false
+          VALIDATE_PHP_PSALM: false
+          # 240519 .shfmt is not taken into account, so far
+          VALIDATE_SHELL_SHFMT: false
+
+      # Step for push/pull_request events, using a fixed linter version
+      - name: Lint Code Base (Default)
+        if: ${{ github.event_name != 'workflow_call' }}
+        uses: super-linter/super-linter@main
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+          FILTER_REGEX_EXCLUDE: '.*\/vendor\/.*'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.yml
+          #SHELL_SHFMT_FILE_NAME: .shfmt
+          VALIDATE_ANSIBLE: false
+          VALIDATE_CSS: false
+          # TODO 211017 VALIDATE_GITHUB_ACTIONS returns false positive `unknown Webhook event "workflow_call"`
+          #VALIDATE_GITHUB_ACTIONS: false # 240519 is workflow_call understood?
+          # TODO 211003 returns false positive: {"line":"                    <li><a href=\"https://www.linkedin.com/company/MYCMSPROJECTSPECIFIC\" title=\"{=\"MYCMSPROJECTSPECIFIC na LinkedIn\"|translate}\"><i class=\"fa fa-linkedin\" aria-hidden=\"true\"></i></a></li>","lineNumber":56,"offender":"linkedin.com/company/MYCMSPROJECTSPECIFIC","offenderEntropy":-1,"commit":"","repo":"","repoURL":"","leakURL":"","rule":"LinkedIn Secret Key","commitMessage":"","author":"","email":"","file":".","date":"0001-01-01T00:00:00Z","tags":"secret, LinkedIn"}
+          VALIDATE_GITLEAKS: false
+          # 240803, there's no way to configure JAVASCRIPT_PRETTIER, neither it shows what exactly an issue is. Just 'Code style issue found in file.', which is useless.
+          VALIDATE_JAVASCRIPT_STANDARD: false
+          # TODO VALIDATE_JSCPD later
+          VALIDATE_JSCPD: false
+          # PHPStan run in matrix strategy in php-composer-dependencies-reusable.yml
           VALIDATE_PHP_PHPSTAN: false
           VALIDATE_PHP_PSALM: false
           # 240519 .shfmt is not taken into account, so far

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -49,6 +49,9 @@ jobs:
     runs-on: "${{ inputs.runs-on || 'ubuntu-latest' }}"
     # Limit the running time
     timeout-minutes: 10
+    strategy:
+      matrix:
+        super-linter-version: [ ${{ github.event_name == 'workflow_call' && 'super-linter/super-linter@' + inputs.linter-version || 'super-linter/super-linter@main' }} ]
 
     ##################
     # Load all steps #
@@ -88,7 +91,7 @@ jobs:
       # However, the `uses` field in a step is processed very early—before runtime—so it requires a static string.
       - name: Lint Code Base (Workflow Call)
         if: ${{ github.event_name == 'workflow_call' }}
-        uses: super-linter/super-linter${{ inputs['linter-version'] }}
+        uses: ${{ matrix.super-linter-version }}
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -78,7 +78,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base (Default)
-        uses: super-linter/super-linter/slim@latest
+        uses: super-linter/super-linter/slim@v7.2.1
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -51,7 +51,8 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        super-linter-version: [ ${{ github.event_name == 'workflow_call' && 'super-linter/super-linter@' + inputs.linter-version || 'super-linter/super-linter@main' }} ]
+        super-linter-version:
+          - ${{ github.event_name == 'workflow_call' && 'super-linter/super-linter@' + inputs['linter-version'] || 'super-linter/super-linter@main' }}
 
     ##################
     # Load all steps #

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -29,11 +29,6 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
-      linter-version:
-        required: false
-        type: string
-        # This parameter allows you to change the super-linter version/branch, e.g. '/slim-latest', '@v7.2.1', '/slim@v7.2.1'
-        default: "@main"
 
 permissions:
   contents: read
@@ -49,10 +44,6 @@ jobs:
     runs-on: "${{ inputs.runs-on || 'ubuntu-latest' }}"
     # Limit the running time
     timeout-minutes: 10
-    strategy:
-      matrix:
-        super-linter-version:
-          - ${{ github.event_name == 'workflow_call' && 'super-linter/super-linter@' + inputs['linter-version'] || 'super-linter/super-linter@main' }}
 
     ##################
     # Load all steps #
@@ -86,40 +77,8 @@ jobs:
       ################################
       # Run Linter against code base #
       ################################
-      # The `uses` field is processed before any runtime expressions are evaluated. As a result, even if you define an environment variable or output, you can’t reference it in the `uses` field.
-      # This restriction forces us to either hardcode the version or use conditional steps with static strings.
-      # When your workflow is triggered via a workflow_call, the inputs (like inputs.linter-version) are available for use in expressions throughout the workflow (for example, in environment variables or conditionals).
-      # However, the `uses` field in a step is processed very early—before runtime—so it requires a static string.
-      - name: Lint Code Base (Workflow Call)
-        if: ${{ github.event_name == 'workflow_call' }}
-        uses: ${{ matrix.super-linter-version }}
-        env:
-          VALIDATE_ALL_CODEBASE: true
-          DEFAULT_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
-          FILTER_REGEX_EXCLUDE: '.*\/vendor\/.*'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.yml
-          #SHELL_SHFMT_FILE_NAME: .shfmt
-          VALIDATE_ANSIBLE: false
-          VALIDATE_CSS: false
-          # TODO 211017 VALIDATE_GITHUB_ACTIONS returns false positive `unknown Webhook event "workflow_call"`
-          #VALIDATE_GITHUB_ACTIONS: false # 240519 is workflow_call understood?
-          # TODO 211003 returns false positive: {"line":"                    <li><a href=\"https://www.linkedin.com/company/MYCMSPROJECTSPECIFIC\" title=\"{=\"MYCMSPROJECTSPECIFIC na LinkedIn\"|translate}\"><i class=\"fa fa-linkedin\" aria-hidden=\"true\"></i></a></li>","lineNumber":56,"offender":"linkedin.com/company/MYCMSPROJECTSPECIFIC","offenderEntropy":-1,"commit":"","repo":"","repoURL":"","leakURL":"","rule":"LinkedIn Secret Key","commitMessage":"","author":"","email":"","file":".","date":"0001-01-01T00:00:00Z","tags":"secret, LinkedIn"}
-          VALIDATE_GITLEAKS: false
-          # 240803, there's no way to configure JAVASCRIPT_PRETTIER, neither it shows what exactly an issue is. Just 'Code style issue found in file.', which is useless.
-          VALIDATE_JAVASCRIPT_STANDARD: false
-          # TODO VALIDATE_JSCPD later
-          VALIDATE_JSCPD: false
-          # PHPStan run in matrix strategy in php-composer-dependencies-reusable.yml
-          VALIDATE_PHP_PHPSTAN: false
-          VALIDATE_PHP_PSALM: false
-          # 240519 .shfmt is not taken into account, so far
-          VALIDATE_SHELL_SHFMT: false
-
-      # Step for push/pull_request events, using a fixed linter version
       - name: Lint Code Base (Default)
-        if: ${{ github.event_name != 'workflow_call' }}
-        uses: super-linter/super-linter@main
+        uses: super-linter/super-linter/slim@latest
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -15,13 +15,11 @@ permissions:
 
 jobs:
   prettier-fix:
-    # Run only if the actor is not the GitHub Actions bot
-    # if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     # Limit the running time
     timeout-minutes: 10
     steps:
       - name: Invoke the Prettier fix
-        uses: WorkOfStan/prettier-fix@v1.1.2
+        uses: WorkOfStan/prettier-fix@v1.1.3
         with:
           commit-changes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added` for new features
 
+- linter-version - a parameter to change the super-linter version/branch, e.g. `/slim-latest`, `@v7.2.1`, `/slim@v7.2.1`
+
 ### `Changed` for changes in existing functionality
 
 ### `Deprecated` for soon-to-be removed features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added` for new features
 
-- linter-version - a parameter to change the super-linter version/branch, e.g. `/slim-latest`, `@v7.2.1`, `/slim@v7.2.1`
-
 ### `Changed` for changes in existing functionality
-
-- linter.yml uses: `super-linter/super-linter/slim@latest` (instead of `super-linter/super-linter@main`)
 
 ### `Deprecated` for soon-to-be removed features
 
@@ -22,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+## [0.2.3] - 2025-03-09
+
+Uses super-linter:v7.2.1 which doesn't invoke composer.
+
+### Added
+
+- Dump GitHub Variables for debugging
+
+### Fixed
+
+- linter.yml uses: `super-linter/super-linter/slim@v7.2.1` (instead of `super-linter/super-linter@main`) as v7.3.0 has a bug - composer expects PHP extensions that are not installed within super-linter environment
 
 ## [0.2.2] - 2025-02-21
 
@@ -89,7 +97,8 @@ Proven reusable workflows
 
 - added .shfmt configuration for super-linter but VALIDATE_SHELL_SHFMT: false is the only solution, anyway
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2...v0.2.1
 [0.2]: https://github.com/WorkOfStan/seablast-actions/compare/v0.1.1...v0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
+- linter.yml uses: `super-linter/super-linter/slim@latest` (instead of `super-linter/super-linter@main`)
+
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ jobs:
 With the release of [Super-Linter](https://github.com/super-linter/super-linter) 7.0.0, [Prettier](https://prettier.io/) has become the standard for many file formats, ensuring consistent code styling across your projects.
 Embrace this change and keep your codebase looking sharp by integrating Prettier directly into your workflow: [prettier-fix](https://github.com/marketplace/actions/prettier-fix).
 
+It's not possible to select super-linter version through a parameter, as the `uses` field expects a static string, so at least `super-linter/super-linter/slim@latest` (instead of `super-linter/super-linter@main`)
+is used for sake of efficiency as these linters are not used in PHP anyway: Rustfmt, Rust Clippy, Azure Resource Manager Template Toolkit (arm-ttk), PSScriptAnalyzer, dotnet (.NET) commands and subcommands.
+
 ### SHFMT notes
 
 Super-linter configuration in [linter.yml](./github/workflows/linter.yml) refering to [.github/linters/.shfmt](.github/linters/.shfmt)

--- a/README.md
+++ b/README.md
@@ -82,14 +82,12 @@ jobs:
     with:
       # OPTIONAL runner specification
       runs-on: "ubuntu-latest"
-      # an OPTIONAL parameter to change the super-linter version/branch, e.g. '/slim-latest', '@v7.2.1', '/slim@v7.2.1'
-      linter-version: "@main"
 ```
 
 With the release of [Super-Linter](https://github.com/super-linter/super-linter) 7.0.0, [Prettier](https://prettier.io/) has become the standard for many file formats, ensuring consistent code styling across your projects.
 Embrace this change and keep your codebase looking sharp by integrating Prettier directly into your workflow: [prettier-fix](https://github.com/marketplace/actions/prettier-fix).
 
-It's not possible to select super-linter version through a parameter, as the `uses` field expects a static string, so at least `super-linter/super-linter/slim@latest` (instead of `super-linter/super-linter@main`)
+Note: It's not possible to select super-linter version through a parameter, as the `uses` field expects a static string, so at least `super-linter/super-linter/slim@latest` (instead of `super-linter/super-linter@main`)
 is used for sake of efficiency as these linters are not used in PHP anyway: Rustfmt, Rust Clippy, Azure Resource Manager Template Toolkit (arm-ttk), PSScriptAnalyzer, dotnet (.NET) commands and subcommands.
 
 ### SHFMT notes

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To optimize execution time, the `vendor` folder is cached, allowing dependencies
 - `composer.json` – to track dependency changes.
 - The runner's OS and PHP version – to account for environment-specific variations.
 
-This approach enables cache sharing across branches. However, if the `composer.json` file in the referenced branch (e.g., `dev`) changes, it's recommended to **invalidate the cache** to ensure a fresh `vendor` folder is built from scratch.
+This approach enables cache sharing across branches. However, if the code in the referenced branch (e.g., `dev`) changes, it's recommended to **invalidate the cache** to ensure a fresh `vendor` folder is built from scratch.
 
 The cache name (key) is `phps-${{ runner.os }}-PHP${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}` (because the vendor folder includes PHPStan)
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ jobs:
     with:
       # OPTIONAL runner specification
       runs-on: "ubuntu-latest"
+      # an OPTIONAL parameter to change the super-linter version/branch, e.g. '/slim-latest', '@v7.2.1', '/slim@v7.2.1'
+      linter-version: "@main"
 ```
 
 With the release of [Super-Linter](https://github.com/super-linter/super-linter) 7.0.0, [Prettier](https://prettier.io/) has become the standard for many file formats, ensuring consistent code styling across your projects.


### PR DESCRIPTION
### Added

- Dump GitHub Variables for debugging

### Fixed

- linter.yml uses: `super-linter/super-linter/slim@v7.2.1` (instead of `super-linter/super-linter@main`) as v7.3.0 has a bug - composer expects PHP extensions that are not installed within super-linter environment

Note: It's not possible to select super-linter version through a parameter, as the `uses` field expects a static string, so at least `super-linter/super-linter/slim@latest` (instead of `super-linter/super-linter@main`)
is used for sake of efficiency as these linters are not used in PHP anyway: Rustfmt, Rust Clippy, Azure Resource Manager Template Toolkit (arm-ttk), PSScriptAnalyzer, dotnet (.NET) commands and subcommands.

