### PR TITLE
Auto-generated zizmor.yaml

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -107,15 +107,15 @@ jobs:
         shell: bash
         run: |
           mkdir -p .github/linters
-          cat <<'EOF' > .github/linters/zizmor.yaml
----
-rules:
-  # disables the check - i.e. allows refering to version instead of an exact hash
-  unpinned-uses:
-    config:
-      policies:
-        "*": any
-EOF
+          {
+            echo "---"
+            echo "rules:"
+            echo "  # disables the check - i.e. allows refering to version instead of an exact hash"
+            echo "  unpinned-uses:"
+            echo "    config:"
+            echo "      policies:"
+            echo "        \"*\": any"
+          } > .github/linters/zizmor.yaml
 
       - name: Prepare linter env (CSS + Exclude)
         # because it is not possible to combine VALIDATE_X true and false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -102,6 +102,21 @@ jobs:
           GITHUB_EVENT_PULL_REQUEST_BASE_NAME: ${{ github.event.pull_request.base.name }}
         shell: bash
 
+      - name: Create zizmor.yaml linter config
+        if: ${{ !hashFiles('.github/linters/zizmor.yaml') }}
+        shell: bash
+        run: |
+          mkdir -p .github/linters
+          cat <<'EOF' > .github/linters/zizmor.yaml
+---
+rules:
+  # disables the check - i.e. allows refering to version instead of an exact hash
+  unpinned-uses:
+    config:
+      policies:
+        "*": any
+EOF
+
       - name: Prepare linter env (CSS + Exclude)
         # because it is not possible to combine VALIDATE_X true and false
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.5.1] - 2025-09-07
 
-feat: You can either use your own zizmor.yaml or the GitHub Action auto-generates such [zizmor.yaml](.github/linters/zizmor.yaml) to disable unpinned-uses check is auto-generated, if not present. (Not to force all apps to create this one-purpose
+feat: If there's no `.github/linters/zizmor.yaml` present in the app repo, then this GitHub Action auto-generates such [zizmor.yaml](.github/linters/zizmor.yaml) to disable unpinned-uses check. (Not to force all apps to create a one purpose zizmor.yaml.)
 
 ## [0.2.5] - 2025-08-28
 
@@ -135,7 +135,8 @@ feat: Proven reusable workflows
 
 - added .shfmt configuration for super-linter but VALIDATE_SHELL_SHFMT: false is the only solution, anyway
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.5...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.5.1...HEAD
+[0.2.5.1]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.5...v0.2.5.1
 [0.2.5]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.2...v0.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.5.1] - 2025-09-07
 
-feat: If there's no `.github/linters/zizmor.yaml` present in the app repo, then this GitHub Action auto-generates such [zizmor.yaml](.github/linters/zizmor.yaml) to disable unpinned-uses check. (Not to force all apps to create a one purpose zizmor.yaml.)
+### Added
+
+feat: If there's no `.github/linters/zizmor.yaml` present in the app repository, then this GitHub Action auto-generates such [zizmor.yaml](.github/linters/zizmor.yaml) to disable unpinned-uses check. (Not to force all apps to create a one purpose zizmor.yaml.)
 
 ## [0.2.5] - 2025-08-28
 
-feat: super-linter fixes can be downloaded as an artifact
+feat: super-linter fixes can be downloaded as an artifact.
 
 ### Changed
 
@@ -83,7 +85,7 @@ chore: The cache name starts with `phps-` prefix. PHPCS-fix instead of old phpcb
 
 ## [0.2.1] - 2025-01-18
 
-fix: Fetch the latest changes to allow job chaining
+fix: Fetch the latest changes to allow job chaining.
 
 ### Added
 
@@ -96,7 +98,7 @@ fix: Fetch the latest changes to allow job chaining
 
 ## [0.2] - 2024-11-16
 
-feat: Check PHP syntax and install PHPStan for each PHP version separately
+feat: Check PHP syntax and install PHPStan for each PHP version separately.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [0.2.5.1] - 2025-09-07
+
+feat: You can either use your own zizmor.yaml or the GitHub Action auto-generates such [zizmor.yaml](.github/linters/zizmor.yaml) to disable unpinned-uses check is auto-generated, if not present. (Not to force all apps to create this one-purpose
+
 ## [0.2.5] - 2025-08-28
 
 feat: super-linter fixes can be downloaded as an artifact

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Note 4: composer.json automatically temporarily renamed (and then renamed back) 
 
 Note 5: Copy/paste detection with the default threshold 0% is too strict. Todo consider parametric JSCPD_CONFIG_FILE . So far: `VALIDATE_JSCPD: false`
 
-Note 6: use [zizmor.yaml](.github/linters/zizmor.yaml) in your app to disable unpinned-uses check - Allows referring to an action by version tag instead of exact hash, so that Dependabot can monitor and update versions automatically.
+Note 6: You can either use your own zizmor.yaml or the GitHub Action auto-generates such [zizmor.yaml](.github/linters/zizmor.yaml) to disable unpinned-uses check. That allows referring to an action by version tag instead of exact hash, so that Dependabot can monitor and update versions automatically.
 
 ## Automatic PHP Code Style improvements
 


### PR DESCRIPTION
### Added

feat: If there's no `.github/linters/zizmor.yaml` present in the app repo, then this GitHub Action auto-generates such [zizmor.yaml](.github/linters/zizmor.yaml) to disable unpinned-uses check. (Not to force all apps to create a one purpose zizmor.yaml.)
