### PR TITLE
fix: fix scheduled GitHub Actions by bumping super-linter::v.8.2.0 to v.8.2.1

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -148,7 +148,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8.2.0
+        uses: super-linter/super-linter/slim@v8.2.1
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -22,14 +22,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Invoke the Prettier fix
-        uses: WorkOfStan/prettier-fix@v1.1.6.1
+        uses: WorkOfStan/prettier-fix@v1
         with:
           commit-changes: true
 
   commit-check:
     needs: prettier-fix
     runs-on: ubuntu-latest
-    permissions: # use permissions because use of pr-comments
+    # use permissions because pull-request comments are used
+    permissions:
       contents: read
       pull-requests: write
     # Limit the running time
@@ -40,17 +41,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }} # checkout PR HEAD commit
           fetch-depth: 0 # required for merge-base check
           persist-credentials: false
-      - uses: commit-check/commit-check-action@v1
+      - uses: commit-check/commit-check-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # use GITHUB_TOKEN because use of pr-comments
         with:
           message: true
           # to accept dependabot/github_actions/*
-          branch: false
+          # branch: false # todo might not be necessary as "dependabot[bot]" author is ignored
           author-name: true
           author-email: true
-          commit-signoff: false
-          merge-base: false
-          imperative: false
           job-summary: true
           pr-comments: ${{ github.event_name == 'pull_request' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [0.2.7] - 2025-10-22
+
+fix: fix scheduled GitHub Actions by bumping super-linter::v.8.2.0 to v.8.2.1 (as super-linter::v8.2.0 failed on scheduled tasks with this error: `/action/lib/functions/validation.sh: line 387: GIT_BEFORE_SHA_HEAD: unbound variable`)
+
 ## [0.2.6] - 2025-10-04
 
 chore(super-linter): Bumps [super-linter/super-linter](https://github.com/super-linter/super-linter) from 8.1.0 to 8.2.0.
@@ -153,7 +157,8 @@ feat: Proven reusable workflows
 
 - added .shfmt configuration for super-linter but VALIDATE_SHELL_SHFMT: false is the only solution, anyway
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.6...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.7...HEAD
+[0.2.7]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.5.2...v0.2.6
 [0.2.5.2]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.5.1...v0.2.5.2
 [0.2.5.1]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.5...v0.2.5.1


### PR DESCRIPTION
fix: fix scheduled GitHub Actions by bumping super-linter::v.8.2.0 to v.8.2.1 (as super-linter::v8.2.0 failed on scheduled tasks with this error: `/action/lib/functions/validation.sh: line 387: GIT_BEFORE_SHA_HEAD: unbound variable`)