### PR TITLE
feat: prevent any composer.json file be used by super-linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -111,8 +111,7 @@ jobs:
             dir=$(dirname "$file")
             new_name="$dir/action-${{ github.run_id }}-composer-${idx}.json"
             mv "$file" "$new_name"
-            printf '%s	%s
-' "$new_name" "$file" >> "$map_file"
+            printf '%s\t%s\n' "$new_name" "$file" >> "$map_file"
             idx=$((idx + 1))
           done
           echo "RENAMED_FILES_MAP=$map_file" >> "$GITHUB_ENV"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -96,11 +96,26 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
           #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Temporarily rename composer.json (to prevent invoking composer within super-linter)
-        if: ${{ hashFiles('composer.json') != '' }} # only if composer.json exists
+      - name: Temporarily rename composer.json files (to prevent invoking composer within super-linter)
+        if: ${{ hashFiles('**/composer.json') != '' }} # only if any composer.json exists
         run: |
-          mv composer.json "action-${{ github.run_id }}.composer.json"
-          echo "RENAMED_FILE=action-${{ github.run_id }}.composer.json" >> "$GITHUB_ENV"
+          set -eo pipefail
+          mapfile -t composer_files < <(find . -type f -name composer.json | sort)
+          if [ ${#composer_files[@]} -eq 0 ]; then
+            exit 0
+          fi
+          map_file="action-${{ github.run_id }}-composer-map.txt"
+          : > "$map_file"
+          idx=0
+          for file in "${composer_files[@]}"; do
+            dir=$(dirname "$file")
+            new_name="$dir/action-${{ github.run_id }}-composer-${idx}.json"
+            mv "$file" "$new_name"
+            printf '%s	%s
+' "$new_name" "$file" >> "$map_file"
+            idx=$((idx + 1))
+          done
+          echo "RENAMED_FILES_MAP=$map_file" >> "$GITHUB_ENV"
 
       # Dump the GitHub variables
       - name: Dump GitHub Variables
@@ -198,9 +213,19 @@ jobs:
           VALIDATE_PHP_PHPSTAN: false
           VALIDATE_PHP_PSALM: false
 
-      - name: Restore composer.json
-        if: ${{ always() && env.RENAMED_FILE != '' && hashFiles(env.RENAMED_FILE) != '' }}
-        run: mv "$RENAMED_FILE" composer.json
+      - name: Restore composer.json files
+        if: ${{ always() && env.RENAMED_FILES_MAP != '' }}
+        run: |
+          set -eo pipefail
+          map_file="$RENAMED_FILES_MAP"
+          if [ ! -f "$map_file" ]; then
+            exit 0
+          fi
+          while IFS=$'	' read -r renamed original; do
+            if [ -n "$renamed" ] && [ -f "$renamed" ]; then
+              mv "$renamed" "$original"
+            fi
+          done < "$map_file"
 
       - name: Show what changed even if super-linter fixed it and therefore passed
         if: ${{ always() }} # run even if super-linter failed

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -129,11 +129,10 @@ jobs:
           GITHUB_EVENT_PULL_REQUEST_BASE_NAME: ${{ github.event.pull_request.base.name }}
         shell: bash
 
-      - name: Create zizmor.yaml linter config
+      - name: Create the default zizmor.yaml linter config
         if: ${{ !hashFiles('.github/linters/zizmor.yaml') }}
         shell: bash
         run: |
-          echo "The default .github/linters/zizmor.yaml used"
           mkdir -p .github/linters
           {
             echo "---"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -97,7 +97,8 @@ jobs:
           #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Temporarily rename composer.json files (to prevent invoking composer within super-linter)
-        if: ${{ hashFiles('**/composer.json') != '' }} # only if any composer.json exists
+        # only if any composer.json exists
+        if: ${{ hashFiles('**/composer.json') != '' }}
         run: |
           set -eo pipefail
           mapfile -t composer_files < <(find . -type f -name composer.json | sort)
@@ -132,6 +133,7 @@ jobs:
         if: ${{ !hashFiles('.github/linters/zizmor.yaml') }}
         shell: bash
         run: |
+          echo "The default .github/linters/zizmor.yaml used"
           mkdir -p .github/linters
           {
             echo "---"
@@ -227,7 +229,8 @@ jobs:
           done < "$map_file"
 
       - name: Show what changed even if super-linter fixed it and therefore passed
-        if: ${{ always() }} # run even if super-linter failed
+        # run even if super-linter failed
+        if: ${{ always() }}
         run: |
           if ! git diff --quiet; then
             git status --porcelain

--- a/.github/workflows/overtrue-phplint.yml
+++ b/.github/workflows/overtrue-phplint.yml
@@ -24,8 +24,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
-          fetch-depth: 0 # Fetch all history for all branches and tags. Otherwise github.event.pull_request.base.ref SHA isn't found.
-          persist-credentials: true # git credentials are needed later, `false` would be safer: token not left in git config
+          # Fetch all history for all branches and tags. Otherwise github.event.pull_request.base.ref SHA isn't found.
+          fetch-depth: 0
+          # git credentials are needed later, `false` would be safer: token not left in git config
+          persist-credentials: true
 
       # Fetch latest changes (even by previous job)
       - name: Fetch latest changes

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          persist-credentials: false # safer: token not left in git config
+          # safer: token not left in git config
+          persist-credentials: false
 
       - name: PHP_CodeSniffer phpcbf GitHub Action
         uses: ge-tracker/phpcbf-action@v1

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -38,12 +38,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }} # checkout PR HEAD commit
-          fetch-depth: 0 # required for merge-base check
+          # checkout PR HEAD commit
+          ref: ${{ github.event.pull_request.head.sha }}
+          # required for merge-base check
+          fetch-depth: 0
           persist-credentials: false
       - uses: commit-check/commit-check-action@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # use GITHUB_TOKEN because use of pr-comments
+          # use GITHUB_TOKEN because use of pr-comments
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: true
           # to accept dependabot/github_actions/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.9] - 2026-03-01
 
-### Added
-
-- add note that the default `.github/linters/zizmor.yaml` is used
+feat: prevent any composer.json file be used by super-linter
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
+- linter.yml: temporary composer.json rename now covers every composer.json in the repository (even in subdirectories) and restores them after the run.
+
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
-- linter.yml: temporary composer.json rename now covers every composer.json in the repository (even in subdirectories) and restores them after the run.
-
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
@@ -20,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+## [0.2.9] - 2026-03-01
+
+### Added
+
+- add note that the default `.github/linters/zizmor.yaml` is used
+
+### Changed
+
+- linter.yml: temporary composer.json rename now covers every composer.json in the repository (even in subdirectories) and restores them after the run.
 
 ## [0.2.8] - 2026-02-14
 
@@ -171,7 +179,8 @@ feat: Proven reusable workflows
 
 - added .shfmt configuration for super-linter but VALIDATE_SHELL_SHFMT: false is the only solution, anyway
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.8...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.9...HEAD
+[0.2.9]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.5.2...v0.2.6

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 WorkOfStan
+Copyright (c) 2024-2026 WorkOfStan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Note 2: slim [variant](https://github.com/super-linter/super-linter?tab=readme-o
 
 Note 3: Many FIXes are applied automatically and their result can be downloaded as an artifact and then use locally with `git apply lint-fixes.patch`. If the change is in the `.github/workflows`, it can't be commited by a GitHub Action anyway.
 
-Note 4: composer.json automatically temporarily renamed (and then renamed back) to prevent invoking composer within super-linter, as the environment PHP version (which might not be app relevant) is used and various libraries would be expected that are not part of super-linter environment.
+Note 4: any composer.json automatically temporarily renamed (and then renamed back) to prevent invoking composer within super-linter, as the environment PHP version (which might not be app relevant) is used and various libraries would be expected that are not part of super-linter environment.
 
 Note 5: Copy/paste detection with the default threshold 0% is too strict. Todo consider parametric JSCPD_CONFIG_FILE . So far: `VALIDATE_JSCPD: false`
 


### PR DESCRIPTION
### Changed

- linter.yml: temporary composer.json rename now covers every composer.json in the repository (even in subdirectories) and restores them after the run.