### PR TITLE
ci: bump checkout and super-linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -281,4 +281,4 @@ jobs:
 
       - name: Inform about patch artifact
         if: ${{ failure() && steps.patch.outputs.changed == 'true' && hashFiles('lint-fixes.patch') != '' }}
-        run: echo "::notice title=lint-fixes artifact ready::You can apply locally with `git apply lint-fixes.patch`"
+        run: echo '::notice title=lint-fixes artifact ready::You can apply locally with `git apply lint-fixes.patch`'

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -281,4 +281,8 @@ jobs:
 
       - name: Inform about patch artifact
         if: ${{ failure() && steps.patch.outputs.changed == 'true' && hashFiles('lint-fixes.patch') != '' }}
-        run: echo "::notice title=lint-fixes artifact ready::You can apply locally with \`git apply lint-fixes.patch\`"
+        run: |
+          echo "::notice title=lint-fixes artifact ready::You can apply locally with: git apply lint-fixes.patch"
+          echo "### lint-fixes artifact ready" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "You can apply locally with \`git apply lint-fixes.patch\`." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -281,4 +281,4 @@ jobs:
 
       - name: Inform about patch artifact
         if: ${{ failure() && steps.patch.outputs.changed == 'true' && hashFiles('lint-fixes.patch') != '' }}
-        run: echo '::notice title=lint-fixes artifact ready::You can apply locally with `git apply lint-fixes.patch`'
+        run: echo "::notice title=lint-fixes artifact ready::You can apply locally with \`git apply lint-fixes.patch\`"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -281,8 +281,4 @@ jobs:
 
       - name: Inform about patch artifact
         if: ${{ failure() && steps.patch.outputs.changed == 'true' && hashFiles('lint-fixes.patch') != '' }}
-        run: |
-          echo "::notice title=lint-fixes artifact ready::You can apply locally with: git apply lint-fixes.patch"
-          echo "### lint-fixes artifact ready" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "You can apply locally with \`git apply lint-fixes.patch\`." >> "$GITHUB_STEP_SUMMARY"
+        run: echo "::notice title=lint-fixes artifact ready::You can apply locally with 'git apply lint-fixes.patch'"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -83,7 +83,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           # Fetch all history for all branches and tags. Otherwise github.event.pull_request.base.ref SHA isn't found.
@@ -193,7 +193,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8.6.0
+        uses: super-linter/super-linter/slim@v8.7.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
@@ -281,4 +281,4 @@ jobs:
 
       - name: Inform about patch artifact
         if: ${{ failure() && steps.patch.outputs.changed == 'true' && hashFiles('lint-fixes.patch') != '' }}
-        run: echo "::notice title=lint-fixes artifact ready::You can apply locally with 'git apply lint-fixes.patch'"
+        run: echo "::notice title=lint-fixes artifact ready::You can apply locally with `git apply lint-fixes.patch`"

--- a/.github/workflows/overtrue-phplint.yml
+++ b/.github/workflows/overtrue-phplint.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           # Fetch all history for all branches and tags. Otherwise github.event.pull_request.base.ref SHA isn't found.

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0 # Fetch all history for all branches and tags. Otherwise github.event.pull_request.base.ref SHA isn't found.

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -19,7 +19,7 @@ jobs:
         shell: bash
 
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7
         with:
           # safer: token not left in git config
           persist-credentials: false

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -36,7 +36,7 @@ jobs:
     # Limit the running time
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7
         with:
           # checkout PR HEAD commit
           ref: ${{ github.event.pull_request.head.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ ci: bump checkout and super-linter
 
 ### `Changed` for changes in existing functionality
 
-- Bump reusable workflow checkout steps to `actions/checkout@v7`.
-- Bump super-linter to `super-linter/super-linter/slim@v8.7.0`.
-- Quote the lint-fixes artifact notice command so backticks remain literal.
-
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
@@ -24,6 +20,15 @@ ci: bump checkout and super-linter
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+## [0.2.11] - 2026-06-20
+
+### Changed
+
+- Bump reusable workflow checkout steps to `actions/checkout@v7`.
+- Bump super-linter to `super-linter/super-linter/slim@v8.7.0`.
+- Escape the lint-fixes artifact notice command backticks so they remain literal.
+- Clarify README workflow conditions and deprecated PHPCBF compatibility wording.
 
 ## [0.2.10] - 2026-06-06
 
@@ -196,7 +201,8 @@ feat: Proven reusable workflows
 
 - added .shfmt configuration for super-linter but VALIDATE_SHELL_SHFMT: false is the only solution, anyway
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.10...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.11...HEAD
+[0.2.11]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.10...v0.2.11
 [0.2.10]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.9...v0.2.10
 [0.2.9]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/WorkOfStan/seablast-actions/compare/v0.2.7...v0.2.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-ci: bump checkout and super-linter
-
 ### `Added` for new features
 
 ### `Changed` for changes in existing functionality
@@ -23,11 +21,13 @@ ci: bump checkout and super-linter
 
 ## [0.2.11] - 2026-06-20
 
+ci: bump checkout and super-linter
+
 ### Changed
 
 - Bump reusable workflow checkout steps to `actions/checkout@v7`.
 - Bump super-linter to `super-linter/super-linter/slim@v8.7.0`.
-- Escape the lint-fixes artifact notice command backticks so they remain literal.
+- Show the lint-fixes apply command as plain annotation text and Markdown in the job summary.
 - Clarify README workflow conditions and deprecated PHPCBF compatibility wording.
 
 ## [0.2.10] - 2026-06-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ ci: bump checkout and super-linter
 - Bump reusable workflow checkout steps to `actions/checkout@v7`.
 - Bump super-linter to `super-linter/super-linter/slim@v8.7.0`.
 - Show the lint-fixes apply command as plain annotation text and Markdown in the job summary.
-- Clarify README workflow conditions and deprecated PHPCBF compatibility wording.
+- Clarify `README` workflow conditions and deprecated PHPCBF compatibility wording.
 
 ## [0.2.10] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ci: bump checkout and super-linter
+
 ### `Added` for new features
 
 ### `Changed` for changes in existing functionality
+
+- Bump reusable workflow checkout steps to `actions/checkout@v7`.
+- Bump super-linter to `super-linter/super-linter/slim@v8.7.0`.
+- Format the lint-fixes artifact notice command with backticks.
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ ci: bump checkout and super-linter
 
 - Bump reusable workflow checkout steps to `actions/checkout@v7`.
 - Bump super-linter to `super-linter/super-linter/slim@v8.7.0`.
-- Format the lint-fixes artifact notice command with backticks.
+- Quote the lint-fixes artifact notice command so backticks remain literal.
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ but as this condition works **ONLY** on the default branch, and typically you ne
 there's the second way. Chaining jobs within a single workflow by using `needs` command.
 See <https://github.com/WorkOfStan/seablast-dist/blob/main/.github/workflows/polish-the-code.yml> for an actual example.
 
-## Test composer dependencies, PHPUnit tests (incl. database) and PHPStan check
+## Test Composer dependencies, optional database/PHPUnit, and PHPStan check
 
 ```yml
 jobs:
@@ -47,14 +47,14 @@ jobs:
       runs-on: "ubuntu-latest"
 ```
 
-PHPUnit tests fire up only if `conf/phpunit-github.xml` is present. (This configuration may be different from the usual `./phpunit.xml`.)
+The workflow checks PHP syntax for every selected PHP version and installs or restores Composer dependencies. Database migration runs only if the configured Phinx file is present and PHP >= 7.1. PHPUnit tests fire up only if `conf/phpunit-github.xml` is present and PHP >= 7.1. (This configuration may be different from the usual `./phpunit.xml`.) PHPStan runs only on PHP >= 7.2.
 
 ### Caching Mechanism
 
 To optimize execution time, the `vendor` folder is cached, allowing dependencies to be reused across workflow runs. The cache key is generated based on:
 
-- `composer.json` – to track dependency changes.
-- The runner's OS and PHP version – to account for environment-specific variations.
+- `composer.json` - to track dependency changes.
+- The runner's OS and PHP version - to account for environment-specific variations.
 
 This approach enables cache sharing across branches. However, if the code in the referenced branch (e.g., `dev`) changes, it's recommended to **invalidate the cache** to ensure a fresh `vendor` folder is built from scratch.
 
@@ -112,3 +112,4 @@ Note 6: You can either use your own zizmor.yaml or the GitHub Action auto-genera
 ## Automatic PHP Code Style improvements
 
 Use [PHPCS-Fix](https://github.com/WorkOfStan/phpcs-fix/blob/main/.github/workflows/phpcs-phpcbf.yml).
+The local `.github/workflows/phpcbf.yml` workflow is deprecated and kept only for backward compatibility.


### PR DESCRIPTION
### Changed

- Bump reusable workflow checkout steps to `actions/checkout@v7`.
- Bump super-linter to `super-linter/super-linter/slim@v8.7.0`.
- Show the lint-fixes apply command as plain annotation text and Markdown in the job summary.
- Clarify `README` workflow conditions and deprecated PHPCBF compatibility wording.
